### PR TITLE
soften pyodbc version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 elasticsearch==1.9.0
 pyelasticsearch==1.4
 rdflib==4.2.2
-pyodbc==3.0.10-2
+pyodbc>=3.0.10-2
 urllib3==1.22
 validators==0.12.0
 chardet==3.0.4


### PR DESCRIPTION
While `pip install` under Python 3.6.4 I got a:

> Could not find a version that satisfies the requirement pyodbc==3.0.10-2
...

Fn. For pyodbc, sudo apt install unixodbc-* was necessary as well.